### PR TITLE
Added support for insertion of attributes in modifyFlow

### DIFF
--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
@@ -258,8 +258,8 @@ object DicomFlows {
             updateSyntax(header)
             if (sequenceDepth == 0)
               modificationsLeft
-                .find(_.tag < header.tag)
                 .filter(_.insert)
+                .find(_.tag < header.tag)
                 .map(modification => headerAndValue(modification.tag) ::: header :: Nil)
                 .getOrElse(modificationsLeft
                   .find(_.tag == header.tag)

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
@@ -214,9 +214,9 @@ object DicomFlows {
   case class TagModification(tag: Int, modification: ByteString => ByteString, insert: Boolean)
 
   /**
-    * Simple transformation flow for inserting or overwriting the values of specified attributes. Only modifies or
+    * Simple modification flow for inserting or overwriting the values of specified attributes. Only modifies or
     * inserts attributes in the root dataset, not inside sequences. When inserting a new attribute, the corresponding
-    * transform will be called with an empty `ByteString`.
+    * modification function will be called with an empty `ByteString`.
     *
     * @param modifications Any number of `TagModification`s each specifying a tag number, a modification function, and
     *                      a Boolean indicating whether absent values will be inserted or skipped.

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
@@ -260,6 +260,7 @@ object DicomFlows {
               val inserts = modificationsLeft
                 .filter(_.insert)
                 .filter(_.tag < header.tag)
+                .sortBy(_.tag)
                 .flatMap(modification => headerAndValue(modification.tag))
               val modify = modificationsLeft
                 .find(_.tag == header.tag)

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
@@ -295,6 +295,7 @@ object DicomFlows {
           case DicomEndMarker =>
             modificationsLeft
               .filter(_.insert)
+              .sortBy(_.tag)
               .flatMap(modification => headerAndValue(modification.tag))
           case part =>
             part :: Nil

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomParsing.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomParsing.scala
@@ -213,6 +213,9 @@ trait DicomParsing {
   def intToBytes(i: Int, bigEndian: Boolean): ByteString = if (bigEndian) intToBytesBE(i) else intToBytesLE(i)
   def intToBytesBE(i: Int): ByteString = ByteString((i >> 24).toByte, (i >> 16).toByte, (i >> 8).toByte, i.toByte)
   def intToBytesLE(i: Int): ByteString = ByteString(i.toByte, (i >> 8).toByte, (i >> 16).toByte, (i >> 24).toByte)
+  def tagToBytes(tag: Int, bigEndian: Boolean): ByteString = if (bigEndian) tagToBytesBE(tag) else tagToBytesLE(tag)
+  def tagToBytesBE(tag: Int): ByteString = intToBytesBE(tag)
+  def tagToBytesLE(tag: Int): ByteString = ByteString((tag >> 16).toByte, (tag >> 24).toByte, tag.toByte,(tag >> 8).toByte)
 
 }
 

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomParts.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomParts.scala
@@ -105,11 +105,7 @@ object DicomParts {
     def bytes = header.bytes ++ valueBytes
     def bigEndian = header.bigEndian
 
-    // LO: long string 64 chars max
-    // SH: short string 16 chars max
-    // PN: person name
-    // UI: 64 chars max
-    def withUpdatedStringValue(newValue: String, cs: SpecificCharacterSet = SpecificCharacterSet.ASCII): DicomAttribute = {
+    def withUpdatedValue(newValue: String, cs: SpecificCharacterSet = SpecificCharacterSet.ASCII): DicomAttribute = {
       val newBytes = header.vr.toBytes(newValue, cs)
       val needsPadding = newBytes.size % 2 == 1
       val newLength = if (needsPadding) newBytes.size + 1 else newBytes.size
@@ -119,13 +115,6 @@ object DicomParts {
       else
         ByteString.fromArray(newBytes)
       DicomAttribute(updatedHeader, Seq(DicomValueChunk(header.bigEndian, updatedValue, last = true)))
-    }
-
-    // DA: A string of characters of the format YYYYMMDD, 8 bytes fixed
-    def withUpdatedDateValue(newValue: String, cs: SpecificCharacterSet = SpecificCharacterSet.ASCII): DicomAttribute = {
-      val newBytes = header.vr.toBytes(newValue, cs)
-      val updatedValue = ByteString.fromArray(newBytes)
-      DicomAttribute(header, Seq(DicomValueChunk(header.bigEndian, updatedValue, last = true)))
     }
 
     def asDicomParts: Seq[DicomPart] = header +: valueChunks

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomParts.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomParts.scala
@@ -47,7 +47,7 @@ object DicomParts {
       DicomHeader(tag, vr, newLength, isFmi, bigEndian, explicitVR, updated)
     }
 
-    override def toString = s"DicomHeader ${TagUtils.toHexString(tag)} ${if (isFmi) "(meta) " else ""}$vr ${if (!explicitVR) "(implicit) " else ""}length = $length ${if (bigEndian) "(big endian) " else "" }$bytes"
+    override def toString = s"DicomHeader ${TagUtils.toString(tag)} ${if (isFmi) "(meta) " else ""}$vr ${if (!explicitVR) "(implicit) " else ""}length = $length ${if (bigEndian) "(big endian) " else "" }$bytes"
   }
 
   object DicomHeader {
@@ -70,7 +70,9 @@ object DicomParts {
     }
   }
 
-  case class DicomValueChunk(bigEndian: Boolean, bytes: ByteString, last: Boolean) extends DicomPart {}
+  case class DicomValueChunk(bigEndian: Boolean, bytes: ByteString, last: Boolean) extends DicomPart {
+    override def toString = s"DicomValueChunk ${if (last) "(last) " else ""}length = ${bytes.length} ${if (bigEndian) "(big endian) " else ""}ASCII = '${new String(bytes.toArray, "US-ASCII")}' $bytes"
+  }
 
   case class DicomDeflatedChunk(bigEndian: Boolean, bytes: ByteString) extends DicomPart
 
@@ -81,13 +83,13 @@ object DicomParts {
   case class DicomItemDelimitation(bigEndian: Boolean, bytes: ByteString) extends DicomPart
 
   case class DicomSequence(tag: Int, bigEndian: Boolean, bytes: ByteString) extends DicomPart {
-    override def toString = s"DicomSequence ${TagUtils.toHexString(tag)} ${if (bigEndian) "(big endian) " else "" }$bytes"
+    override def toString = s"DicomSequence ${TagUtils.toString(tag)} ${if (bigEndian) "(big endian) " else "" }$bytes"
   }
 
   case class DicomSequenceDelimitation(bigEndian: Boolean, bytes: ByteString) extends DicomPart
 
   case class DicomFragments(tag: Int, vr: VR, bigEndian: Boolean, bytes: ByteString) extends DicomPart {
-    override def toString = s"DicomFragments ${TagUtils.toHexString(tag)} $vr ${if (bigEndian) "(big endian) " else "" }$bytes"
+    override def toString = s"DicomFragments ${TagUtils.toString(tag)} $vr ${if (bigEndian) "(big endian) " else "" }$bytes"
   }
 
   case class DicomFragmentsDelimitation(bigEndian: Boolean, bytes: ByteString) extends DicomPart

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomFlowsTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomFlowsTest.scala
@@ -247,14 +247,14 @@ class DicomFlowsTest extends TestKit(ActorSystem("DicomAttributesSinkSpec")) wit
       .expectDicomComplete()
   }
 
-  "The transform flow" should "transform the value of the specified attributes" in {
+  "The modify flow" should "modify the value of the specified attributes" in {
     val bytes = patientNameJohnDoe ++ studyDate
 
     val mikeBytes = ByteString('M', 'i', 'k', 'e')
 
     val source = Source.single(bytes)
       .via(new DicomPartFlow())
-      .via(attributesTransformFlow((Tag.PatientName, _ => mikeBytes), (Tag.StudyDate, _ => ByteString.empty)))
+      .via(modifyFlow(insertIfAbsent = false, (Tag.PatientName, _ => mikeBytes), (Tag.StudyDate, _ => ByteString.empty)))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.PatientName, VR.PN, mikeBytes.length)
@@ -264,25 +264,57 @@ class DicomFlowsTest extends TestKit(ActorSystem("DicomAttributesSinkSpec")) wit
       .expectDicomComplete()
   }
 
-  it should "transform attributes in sequences" in {
+  it should "not modify attributes in sequences" in {
     val bytes = seqStart ++ itemNoLength ++ patientNameJohnDoe ++ studyDate ++ itemEnd ++ seqEnd
 
     val mikeBytes = ByteString('M', 'i', 'k', 'e')
 
     val source = Source.single(bytes)
       .via(new DicomPartFlow())
-      .via(attributesTransformFlow((Tag.PatientName, _ => mikeBytes)))
+      .via(modifyFlow(insertIfAbsent = false, (Tag.PatientName, _ => mikeBytes)))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
       .expectItem()
-      .expectHeader(Tag.PatientName, VR.PN, mikeBytes.length)
-      .expectValueChunk(mikeBytes)
+      .expectHeader(Tag.PatientName, VR.PN, patientNameJohnDoe.length - 8)
+      .expectValueChunk(patientNameJohnDoe.drop(8))
       .expectHeader(Tag.StudyDate)
       .expectValueChunk()
       .expectItemDelimitation()
       .expectSequenceDelimitation()
       .expectDicomComplete()
+  }
+
+  it should "insert attributes if not present" in {
+    val bytes = patientNameJohnDoe
+
+    val source = Source.single(bytes)
+      .via(new DicomPartFlow())
+      .via(modifyFlow(insertIfAbsent = true, (Tag.StudyDate, _ => studyDate.drop(8))))
+
+    source.runWith(TestSink.probe[DicomPart])
+      .expectHeader(Tag.StudyDate, VR.DA, studyDate.length - 8)
+      .expectValueChunk(studyDate.drop(8))
+      .expectHeader(Tag.PatientName, VR.PN, patientNameJohnDoe.length - 8)
+      .expectValueChunk(patientNameJohnDoe.drop(8))
+      .expectDicomComplete()
+
+  }
+
+  it should "insert attributes if not present also at end of dataset" in {
+    val bytes = studyDate
+
+    val source = Source.single(bytes)
+      .via(new DicomPartFlow())
+      .via(modifyFlow(insertIfAbsent = true, (Tag.PatientName, _ => patientNameJohnDoe.drop(8))))
+
+    source.runWith(TestSink.probe[DicomPart])
+      .expectHeader(Tag.StudyDate, VR.DA, studyDate.length - 8)
+      .expectValueChunk(studyDate.drop(8))
+      .expectHeader(Tag.PatientName, VR.PN, patientNameJohnDoe.length - 8)
+      .expectValueChunk(patientNameJohnDoe.drop(8))
+      .expectDicomComplete()
+
   }
 
   "The deflate flow" should "recreate the dicom parts of a dataset which has been deflated and inflated again" in {
@@ -291,9 +323,10 @@ class DicomFlowsTest extends TestKit(ActorSystem("DicomAttributesSinkSpec")) wit
     val source = Source.single(bytes)
       .via(new DicomPartFlow())
       .via(deflateDatasetFlow())
-      .via(attributesTransformFlow(
+      .via(modifyFlow(
+        insertIfAbsent = false,
         (Tag.FileMetaInformationGroupLength, _ => fmiGroupLength(tsuidDeflatedExplicitLE)),
-        (Tag.TransferSyntaxUID, _ => ByteString('1', '.', '2', '.', '8', '4', '0', '.', '1', '0', '0', '0', '8', '.', '1', '.', '2', '.', '1', '.', '9', '9'))))
+        (Tag.TransferSyntaxUID, _ => tsuidDeflatedExplicitLE.drop(8))))
       .map(_.bytes)
       .via(new DicomPartFlow())
 

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomFlowsTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomFlowsTest.scala
@@ -323,8 +323,8 @@ class DicomFlowsTest extends TestKit(ActorSystem("DicomAttributesSinkSpec")) wit
     val source = Source.single(bytes)
       .via(new DicomPartFlow())
       .via(modifyFlow(
-        TagModification(Tag.StudyDate, _ => studyDate.drop(8), insert = true),
-        TagModification(Tag.SeriesDate, _ => studyDate.drop(8), insert = true)))
+        TagModification(Tag.SeriesDate, _ => studyDate.drop(8), insert = true),
+        TagModification(Tag.StudyDate, _ => studyDate.drop(8), insert = true)))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, studyDate.length - 8)

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomPartFlowTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomPartFlowTest.scala
@@ -62,6 +62,18 @@ class DicomPartFlowTest extends TestKit(ActorSystem("DicomFlowSpec")) with FlatS
       .expectDicomComplete()
   }
 
+  it should "output an empty value chunk when value length is zero, except if at end of stream" in {
+    val bytes = ByteString(8, 0, 32, 0, 68, 65, 0, 0) ++ ByteString(16, 0, 16, 0, 80, 78, 0, 0)
+    val source = Source.single(bytes)
+      .via(new DicomPartFlow())
+
+    source.runWith(TestSink.probe[DicomPart])
+      .expectHeader(Tag.StudyDate)
+      .expectValueChunk()
+      .expectHeader(Tag.PatientName)
+      .expectDicomComplete()
+  }
+
   it should "output a warning message when non-meta information is included in the header" in {
     val bytes = fmiGroupLength(tsuidExplicitLE, studyDate) ++ tsuidExplicitLE ++ studyDate
 

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomPartFlowTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomPartFlowTest.scala
@@ -62,7 +62,7 @@ class DicomPartFlowTest extends TestKit(ActorSystem("DicomFlowSpec")) with FlatS
       .expectDicomComplete()
   }
 
-  it should "output an empty value chunk when value length is zero, except if at end of stream" in {
+  it should "output an empty value chunk when value length is zero" in {
     val bytes = ByteString(8, 0, 32, 0, 68, 65, 0, 0) ++ ByteString(16, 0, 16, 0, 80, 78, 0, 0)
     val source = Source.single(bytes)
       .via(new DicomPartFlow())
@@ -71,6 +71,7 @@ class DicomPartFlowTest extends TestKit(ActorSystem("DicomFlowSpec")) with FlatS
       .expectHeader(Tag.StudyDate)
       .expectValueChunk()
       .expectHeader(Tag.PatientName)
+      .expectValueChunk()
       .expectDicomComplete()
   }
 

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomPartsTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomPartsTest.scala
@@ -8,8 +8,8 @@ import se.nimsa.dcm4che.streams.DicomParts.{DicomAttribute, DicomHeader, DicomVa
 class DicomPartsTest extends FlatSpecLike with Matchers {
 
   "DicomHeader" should "should return a new header with modified length for explicitVR, LE" in {
-    val (tag, vr, headerLength, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, false).get
-    val header = DicomHeader(tag, vr, length, false, false, true, patientNameJohnDoe.take(8))
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true, patientNameJohnDoe.take(8))
     val updatedHeader = header.withUpdatedLength(5)
 
     updatedHeader.length shouldEqual 5
@@ -19,8 +19,8 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
   }
 
   it should "should return a new header with modified length for explicitVR, BE" in {
-    val (tag, vr, headerLength, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoeBE, true).get
-    val header = DicomHeader(tag, vr, length, false, true, true, patientNameJohnDoeBE.take(8))
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoeBE, assumeBigEndian = true).get
+    val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = true, explicitVR = true, patientNameJohnDoeBE.take(8))
     val updatedHeader = header.withUpdatedLength(5)
 
     updatedHeader.length shouldEqual 5
@@ -30,8 +30,8 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
   }
 
   it should "should return a new header with modified length for implicitVR, LE" in {
-    val (tag, vr, headerLength, length) = DicomParsing.readHeaderImplicitVR(patientNameJohnDoeImplicit).get
-    val header = DicomHeader(tag, vr, length, false, false, false, patientNameJohnDoeImplicit.take(8))
+    val (tag, vr, _, length) = DicomParsing.readHeaderImplicitVR(patientNameJohnDoeImplicit).get
+    val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = false, patientNameJohnDoeImplicit.take(8))
     val updatedHeader = header.withUpdatedLength(5)
 
     updatedHeader.length shouldEqual 5
@@ -40,11 +40,28 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
     updatedHeader.bytes(5) shouldEqual 0
   }
 
+  it should "create a valid explicit VR little endian byte sequence representation when constructed without explicit bytes" in {
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val bytes = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true).bytes
+    bytes shouldBe patientNameJohnDoe.take(8)
+  }
+
+  it should "create a valid implicit VR little endian byte sequence representation when constructed without explicit bytes" in {
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val bytes = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = false).bytes
+    bytes shouldBe patientNameJohnDoeImplicit.take(8)
+  }
+
+  it should "create a valid explicit VR big endian byte sequence representation when constructed without explicit bytes" in {
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val bytes = DicomHeader(tag, vr, length, isFmi = false, bigEndian = true, explicitVR = true).bytes
+    bytes shouldBe patientNameJohnDoeBE.take(8)
+  }
 
   "DicomAttribute" should "should return a new attribute with updated header and updated value" in {
-    val (tag, vr, headerLength, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, false).get
-    val header = DicomHeader(tag, vr, length, false, false, true, patientNameJohnDoe.take(8))
-    val value = DicomValueChunk(false, patientNameJohnDoe.drop(8) ,true)
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true, patientNameJohnDoe.take(8))
+    val value = DicomValueChunk(bigEndian = false, patientNameJohnDoe.drop(8) ,last = true)
     val attribute = DicomAttribute(header, Seq(value))
     val updatedAttribute = attribute.withUpdatedStringValue("Jimmyboy^Doe")
     updatedAttribute.valueBytes.size shouldEqual 12
@@ -53,9 +70,9 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
   }
 
   it should "should return a new attribute with updated header and updated value with padding" in {
-    val (tag, vr, headerLength, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, false).get
-    val header = DicomHeader(tag, vr, length, false, false, true, patientNameJohnDoe.take(8))
-    val value = DicomValueChunk(false, patientNameJohnDoe.drop(8) ,true)
+    val (tag, vr, _, length) = DicomParsing.readHeaderExplicitVR(patientNameJohnDoe, assumeBigEndian = false).get
+    val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true, patientNameJohnDoe.take(8))
+    val value = DicomValueChunk(bigEndian = false, patientNameJohnDoe.drop(8) ,last = true)
     val attribute = DicomAttribute(header, Seq(value))
     val updatedAttribute = attribute.withUpdatedStringValue("Jimmy^Doe")
 

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomPartsTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomPartsTest.scala
@@ -63,7 +63,7 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
     val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true, patientNameJohnDoe.take(8))
     val value = DicomValueChunk(bigEndian = false, patientNameJohnDoe.drop(8) ,last = true)
     val attribute = DicomAttribute(header, Seq(value))
-    val updatedAttribute = attribute.withUpdatedStringValue("Jimmyboy^Doe")
+    val updatedAttribute = attribute.withUpdatedValue("Jimmyboy^Doe")
     updatedAttribute.valueBytes.size shouldEqual 12
     updatedAttribute.header.length shouldEqual 12
     updatedAttribute.bytes.size shouldEqual 20
@@ -74,7 +74,7 @@ class DicomPartsTest extends FlatSpecLike with Matchers {
     val header = DicomHeader(tag, vr, length, isFmi = false, bigEndian = false, explicitVR = true, patientNameJohnDoe.take(8))
     val value = DicomValueChunk(bigEndian = false, patientNameJohnDoe.drop(8) ,last = true)
     val attribute = DicomAttribute(header, Seq(value))
-    val updatedAttribute = attribute.withUpdatedStringValue("Jimmy^Doe")
+    val updatedAttribute = attribute.withUpdatedValue("Jimmy^Doe")
 
     updatedAttribute.valueBytes.size shouldEqual 10
     updatedAttribute.header.length shouldEqual 10


### PR DESCRIPTION
Fixes #27. We need this for the upcoming work on an anonymization flow in slicebox. For instance, we need to be able to insert the tag PatientIdentityRemoved=YES if not present or correct.