### PR TITLE
Feature/validation with draining

### DIFF
--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomFlows.scala
@@ -180,14 +180,14 @@ object DicomFlows {
     * attribute found
     */
   val validateFlow: Flow[ByteString, ByteString, NotUsed] =
-    Flow[ByteString].via(new DicomValidateFlow(None))
+    Flow[ByteString].via(new DicomValidateFlow(None, drainIncoming = false))
 
   /**
     * A flow which passes on the input bytes unchanged, fails for non-DICOM files, validates for DICOM files with supported
     * Media Storage SOP Class UID, Transfer Syntax UID combination passed as context
     */
-  def validateFlowWithContext(contexts: Seq[ValidationContext]): Flow[ByteString, ByteString, NotUsed] =
-    Flow[ByteString].via(new DicomValidateFlow(Some(contexts)))
+  def validateFlowWithContext(contexts: Seq[ValidationContext], drainIncoming: Boolean): Flow[ByteString, ByteString, NotUsed] =
+    Flow[ByteString].via(new DicomValidateFlow(Some(contexts), drainIncoming))
 
   /**
     * A flow which deflates the dataset but leaves the meta information intact. Useful when the dicom parsing in `DicomParseFlow`

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomValidateFlow.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomValidateFlow.scala
@@ -46,9 +46,8 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
 
     setHandlers(in, out, new InHandler with OutHandler {
 
-      override def onPull(): Unit = {
+      override def onPull(): Unit =
         pull(in)
-      }
 
       override def onPush(): Unit = {
         val chunk = grab(in)
@@ -87,24 +86,21 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
       override def onUpstreamFinish(): Unit = {
         isValidated match {
           case None =>
-            if (contexts.isDefined) {
+            if (contexts.isDefined)
               if (buffer.length >= dicomPreambleLength && isPreamble(buffer)) {
                 val info = DicomParsing.dicomInfo(buffer.drop(dicomPreambleLength)).get
                 validateFileMetaInformation(buffer.drop(dicomPreambleLength), info)
               } else if (buffer.length >= 8 && DicomParsing.isHeader(buffer)) {
                 val info = DicomParsing.dicomInfo(buffer).get
                 validateSOPClassUID(buffer, info)
-              } else {
+              } else
                 setFailed(new DicomStreamException("Not a DICOM stream"))
-              }
-            } else {
-              if (buffer.length == dicomPreambleLength && isPreamble(buffer))
-                setValidated()
-              else if (buffer.length >= 8 && DicomParsing.isHeader(buffer))
-                setValidated()
-              else
-                setFailed(new DicomStreamException("Not a DICOM stream"))
-            }
+            else if (buffer.length == dicomPreambleLength && isPreamble(buffer))
+              setValidated()
+            else if (buffer.length >= 8 && DicomParsing.isHeader(buffer))
+              setValidated()
+            else
+              setFailed(new DicomStreamException("Not a DICOM stream"))
             completeStage()
           case Some(true) =>
             completeStage()
@@ -129,11 +125,10 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
             val tsuid = DicomParsing.parseUIDAttribute(currentData, info.explicitVR, info.bigEndian)
 
             val currentContext = ValidationContext(mscu.value.utf8String, tsuid.value.utf8String)
-            if (contexts.get.contains(currentContext)) {
+            if (contexts.get.contains(currentContext))
               setValidated()
-            } else {
+            else
               setFailed(new DicomStreamException(s"The presentation context [SOPClassUID = ${mscu.value.utf8String}, TransferSyntaxUID = ${tsuid.value.utf8String}] is not supported"))
-            }
           }
         }
       }
@@ -152,11 +147,10 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
           val tsuid = info.assumedTransferSyntax
 
           val currentContext = ValidationContext(scuid.value.utf8String, tsuid)
-          if (contexts.get.contains(currentContext)) {
+          if (contexts.get.contains(currentContext))
             setValidated()
-          } else {
+          else
             setFailed(new DicomStreamException(s"The presentation context [SOPClassUID = ${scuid.value.utf8String}, TransferSyntaxUID = $tsuid] is not supported"))
-          }
         }
       }
 
@@ -186,9 +180,8 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
               setFailed(new DicomStreamException(s"Parse error. Invalid tag order or invalid DICOM header: ${takeMax8(currentData)}."))
             } else {
               currentTag = tag
-              if (!found(tag)) {
+              if (!found(tag))
                 currentData = currentData.drop(headerLength + length.toInt)
-              }
               if (stopSearching(currentTag) || currentData.size < 8) {
                 // read past stop criteria without finding tag, or not enough data left in buffer
                 failed = true

--- a/src/main/scala/se/nimsa/dcm4che/streams/DicomValidateFlow.scala
+++ b/src/main/scala/se/nimsa/dcm4che/streams/DicomValidateFlow.scala
@@ -21,7 +21,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
 import org.dcm4che3.io.DicomStreamException
 import se.nimsa.dcm4che.streams.DicomFlows.ValidationContext
-import se.nimsa.dcm4che.streams.DicomParsing.{Info, isPreamble, dicomPreambleLength}
+import se.nimsa.dcm4che.streams.DicomParsing.{Info, dicomPreambleLength, isPreamble}
 import org.dcm4che3.data.Tag._
 
 /**
@@ -94,13 +94,13 @@ class DicomValidateFlow(contexts: Option[Seq[ValidationContext]], drainIncoming:
                 val info = DicomParsing.dicomInfo(buffer).get
                 validateSOPClassUID(buffer, info)
               } else
-                setFailed(new DicomStreamException("Not a DICOM stream"))
+                failStage(new DicomStreamException("Not a DICOM stream"))
             else if (buffer.length == dicomPreambleLength && isPreamble(buffer))
               setValidated()
             else if (buffer.length >= 8 && DicomParsing.isHeader(buffer))
               setValidated()
             else
-              setFailed(new DicomStreamException("Not a DICOM stream"))
+              failStage(new DicomStreamException("Not a DICOM stream"))
             completeStage()
           case Some(true) =>
             completeStage()

--- a/src/test/scala/se/nimsa/dcm4che/streams/DicomValidateFlowsTest.scala
+++ b/src/test/scala/se/nimsa/dcm4che/streams/DicomValidateFlowsTest.scala
@@ -2,14 +2,15 @@ package se.nimsa.dcm4che.streams
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.dcm4che3.data.UID._
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.duration.DurationInt
 
 class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec")) with FlatSpecLike with Matchers with BeforeAndAfterAll {
 
@@ -100,7 +101,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     val source = Source.single(bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -125,7 +126,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -136,7 +137,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with less than 512 bytes
     source = Source.single(bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -161,7 +162,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -170,7 +171,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with less than 512 bytes
     source = Source.single(bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -192,7 +193,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -203,7 +204,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with less than 512 bytes
     source = Source.single(bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -224,7 +225,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -235,7 +236,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
     // test with less than 512 bytes
     source = Source.single(bytes)
       .via(new Chunker(1))
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -263,7 +264,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -271,7 +272,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with less than 512 bytes
     source = Source.single(bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -287,7 +288,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -295,7 +296,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with less than 512 bytes
     source = Source.single(bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -312,7 +313,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -320,7 +321,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with less than 512 bytes
     source = Source.single(bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -337,7 +338,7 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with more than 512 bytes
     var source = Source.single(moreThan512Bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
@@ -346,12 +347,60 @@ class DicomValidateFlowsTest extends TestKit(ActorSystem("DicomValidateFlowsSpec
 
     // test with less than 512 bytes
     source = Source.single(bytes)
-      .via(validateFlowWithContext(contexts))
+      .via(validateFlowWithContext(contexts, drainIncoming = false))
 
     source.runWith(TestSink.probe[ByteString])
       .request(1)
       .expectNext(bytes)
       .expectComplete()
+  }
+
+  it should "stop requesting data once validation has failed if asked to not drain incoming data" in {
+    var nItems = 0
+
+    val bytesSource = Source.fromIterator(() => (1 to 10000)
+      .map(_.toByte).iterator)
+      .grouped(1000)
+      .map(bytes => ByteString(bytes.toArray))
+      .map(bs => {
+        nItems += 1
+        bs
+      })
+
+    val f = bytesSource
+      .via(new DicomValidateFlow(None, drainIncoming = false))
+      .runWith(Sink.ignore)
+
+    Await.ready(f, 5.seconds)
+
+    nItems shouldBe 1
+  }
+
+  it should "keep requesting data until finished after validation failed, but not emit more data when asked to drain incoming data" in {
+    var nItemsRequested = 0
+    var nItemsEmitted = 0
+
+    val bytesSource = Source.fromIterator(() => (1 to 10000)
+      .map(_.toByte).iterator)
+      .grouped(1000)
+      .map(bytes => ByteString(bytes.toArray))
+      .map(bs => {
+        nItemsRequested += 1
+        bs
+      })
+
+    val f = bytesSource
+      .via(new DicomValidateFlow(None, drainIncoming = true))
+      .map(bs => {
+        nItemsEmitted += 1
+        bs
+      })
+      .runWith(Sink.ignore)
+
+    Await.ready(f, 5.seconds)
+
+    nItemsRequested shouldBe 10
+    nItemsEmitted shouldBe 0
   }
 
 }


### PR DESCRIPTION
Added option to drain upstream in DicomValidationFlow in cases where dicom validation fails, instead of just failing the stage before all bytes have been received.  This may be beneficial when upstream is a http entity received from a client. If bytes are not drained/consumed, the connnection will be abruptly closed which is unexpected for the client and may hurt performance.